### PR TITLE
Refactor auth flow: separate login/register pages with modal and redirect

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Metadata } from 'next'
+import AuthModal from '../../../components/auth/AuthModal'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [isModalOpen, setIsModalOpen] = useState(true)
+  const [mode, setMode] = useState<'login' | 'register'>('login')
+
+  const handleClose = () => {
+    setIsModalOpen(false)
+    router.push('/')
+  }
+
+  const handleModeChange = (newMode: 'login' | 'register') => {
+    setMode(newMode)
+    if (newMode === 'register') {
+      router.push('/auth/register')
+    }
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%)',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+    }}>
+      <AuthModal 
+        isOpen={isModalOpen}
+        onClose={handleClose}
+        mode={mode}
+        onModeChange={handleModeChange}
+      />
+    </div>
+  )
+}

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import React, { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Metadata } from 'next'
+import AuthModal from '../../../components/auth/AuthModal'
+
+export default function RegisterPage() {
+  const router = useRouter()
+  const [isModalOpen, setIsModalOpen] = useState(true)
+  const [mode, setMode] = useState<'login' | 'register'>('register')
+
+  const handleClose = () => {
+    setIsModalOpen(false)
+    router.push('/')
+  }
+
+  const handleModeChange = (newMode: 'login' | 'register') => {
+    setMode(newMode)
+    if (newMode === 'login') {
+      router.push('/auth/login')
+    }
+  }
+
+  return (
+    <div style={{
+      minHeight: '100vh',
+      background: 'linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%)',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif'
+    }}>
+      <AuthModal 
+        isOpen={isModalOpen}
+        onClose={handleClose}
+        mode={mode}
+        onModeChange={handleModeChange}
+      />
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import EVMarketplace from '../components/EVMarketplaceRefactored';
+import EVMarketplace from '../components/EVMarketplaceRedirected';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {

--- a/src/components/EVMarketplaceRedirected.tsx
+++ b/src/components/EVMarketplaceRedirected.tsx
@@ -840,8 +840,7 @@ export default function EVMarketplace() {
               <>
                 <button 
                   onClick={() => {
-                    setAuthMode('login');
-                    setShowAuthModal(true);
+                    window.location.href = '/auth/login';
                   }}
                   style={{
                     background: 'rgba(255, 255, 255, 0.9)',
@@ -857,8 +856,7 @@ export default function EVMarketplace() {
                 </button>
                 <button 
                   onClick={() => {
-                    setAuthMode('register');
-                    setShowAuthModal(true);
+                    window.location.href = '/auth/register';
                   }}
                   style={{
                     background: 'transparent',

--- a/src/components/auth/RegistrationForm.tsx
+++ b/src/components/auth/RegistrationForm.tsx
@@ -68,7 +68,6 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = ({
     try {
       // Create user profile in Supabase
       await authService.createUserProfile({
-        phone: phone,
         email: formData.email,
         first_name: formData.firstName,
         last_name: formData.lastName,
@@ -78,7 +77,8 @@ export const RegistrationForm: React.FC<RegistrationFormProps> = ({
         postal_code: formData.postalCode || '',
         country: 'Poland',
         company_name: formData.isCompany ? formData.companyName : undefined,
-        nip: formData.isCompany ? formData.nip : undefined
+        nip: formData.isCompany ? formData.nip : undefined,
+        auth_provider: 'email'
       })
 
       // Refresh the user profile in context

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -16,6 +16,8 @@ export interface User {
 }
 
 export interface AuthFormData {
+  phone: string
+  verificationCode: string
   email: string
   firstName: string
   lastName: string
@@ -46,3 +48,7 @@ export interface OAuthResponse {
   message: string
   data?: any
 }
+
+export type AuthMode = 'login' | 'register'
+
+export type PhoneVerificationStep = 'phone' | 'code' | 'details'


### PR DESCRIPTION
## Summary
- Refactors authentication flow by creating separate login and register pages
- Uses `AuthModal` component in both pages with mode switching and modal close handling
- Redirects between login and register pages on mode change
- Updates EVMarketplace component to redirect to new auth pages instead of showing modal
- Adds phone and verification code fields to auth types
- Updates registration form to include `auth_provider` and remove phone from profile creation

## Changes

### Authentication Pages
- Added `src/app/auth/login/page.tsx` for login modal page
- Added `src/app/auth/register/page.tsx` for register modal page
- Both pages use `AuthModal` with controlled open state and mode switching

### EVMarketplace Component
- Changed import to `EVMarketplaceRedirected` in `src/app/page.tsx`
- Updated buttons to redirect to `/auth/login` and `/auth/register` instead of showing modal

### Registration Form
- Removed phone from user profile creation
- Added `auth_provider: 'email'` to profile creation

### Types
- Added `phone` and `verificationCode` to `AuthFormData`
- Added `AuthMode` and `PhoneVerificationStep` types

## Test plan
- [x] Verify login page shows login modal and redirects on close
- [x] Verify register page shows register modal and redirects on close
- [x] Verify switching modes redirects to correct auth page
- [x] Verify EVMarketplace buttons redirect to auth pages
- [x] Verify registration form submits with updated profile data
- [x] Verify type updates do not break existing auth flows

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/594d6fe8-b2a0-412d-b2f8-1f0853381e6c